### PR TITLE
Cbit rails auth

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -54,6 +54,7 @@ group :production do
 end
 
 gem 'foundation-rails'
+gem 'clearbit'
 
 #this is an autocomplete gem for the email field
 gem 'rails-jquery-autocomplete'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -47,6 +47,8 @@ GEM
     bindex (0.5.0)
     builder (3.2.3)
     byebug (9.0.6)
+    clearbit (0.2.7)
+      nestful (~> 1.1.0)
     coffee-rails (4.2.2)
       coffee-script (>= 2.2.0)
       railties (>= 4.0.0)
@@ -86,6 +88,7 @@ GEM
     mini_portile2 (2.2.0)
     minitest (5.10.2)
     multi_json (1.12.1)
+    nestful (1.1.1)
     nio4r (2.1.0)
     nokogiri (1.8.0)
       mini_portile2 (~> 2.2.0)
@@ -172,6 +175,7 @@ PLATFORMS
 DEPENDENCIES
   bcrypt (~> 3.1.7)
   byebug
+  clearbit
   coffee-rails (~> 4.2)
   foundation-rails
   jbuilder (~> 2.5)

--- a/app/assets/javascripts/users.js
+++ b/app/assets/javascripts/users.js
@@ -7,10 +7,9 @@ $(document).on('turbolinks:load', function() {
   $("#email").focusout(function() {
     $.ajax({
       method: 'GET',
-      //API key currently directly in code for testing
-      beforeSend: function (xhr) { xhr.setRequestHeader('Authorization', 'Basic ' + btoa('sk_469ac595952197c04dcb17f6aee47420:'));},
       dataType: 'JSON',
-      url: 'https://person-stream.clearbit.com/v2/combined/find?email=' + $('#email').val()
+      url: '/cbit/' + $('#email').val()
+
       }).done(function(data){
         $('#full_name').val(data.person.name.fullName)
         $('#company_name').val(data.company.legalName)

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,5 +1,5 @@
 class UsersController < ApplicationController
-  # autocomplete :user, :email
+  before_action :clearbit_auth, only: [:get_user_info]
 
   def show
     @user = User.find(params[:user_id])
@@ -19,10 +19,25 @@ class UsersController < ApplicationController
     end
   end
 
+  def get_user_info
+    email =  params[:email] + '.' + params[:format]
+    response = Clearbit::Enrichment.find(email:  email, stream: true)
+
+    if response == nil
+      render body: nil, :status => :not_found
+    else
+      render :json => response
+    end
+  end
+
 private
 
   def user_params
-    params.require(:user).permit(:email, :first_name, :last_name, :role, :company_name, :password)
+    params.require(:user).permit(:email, :full_name,:phone_number, :company_size, :company_name, :password)
+  end
+
+  def clearbit_auth
+    Clearbit.key = ENV[CBIT_API]
   end
 
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,5 +6,7 @@ Rails.application.routes.draw do
     get :autocomplete_user_email, :on => :collection
   end
 
+  get '/cbit/:email', to: 'users#get_user_info', as: 'get_user_info'
+
   resources :sessions, only: %i(create destroy)
 end


### PR DESCRIPTION
This pull moves all the Clearbit processing onto the server side, allowing authentication to be done on the server. This prevents the client from having access to any API keys or processing data!